### PR TITLE
Colored log function patch about naming and else case handling

### DIFF
--- a/Server/app/__init__.py
+++ b/Server/app/__init__.py
@@ -44,7 +44,7 @@ def register_hooks(flask_app):
 
 def create_app(*config_cls) -> Flask:
     log(message='Flask application initialized with {}'.format(', '.join([config.__name__ for config in config_cls])),
-        type='INFO')
+        keyword='INFO')
             
     flask_app = Flask(__name__)
 

--- a/Server/app/misc/log.py
+++ b/Server/app/misc/log.py
@@ -8,3 +8,6 @@ def log(message: str, keyword: str="WARN"):
         print(colored('[ERROR] ' + message, 'red'))
     elif keyword == "INFO":
         print(colored('[INFO]', 'blue'), message)
+    else: 
+        print(colored('[{}]'.format(type), 'cyan'), message)
+

--- a/Server/app/misc/log.py
+++ b/Server/app/misc/log.py
@@ -1,10 +1,10 @@
 from termcolor import colored
 
 
-def log(message: str, type: str="WARN"):
-    if type == "WARN":
+def log(message: str, keyword: str="WARN"):
+    if keyword == "WARN":
         print(colored('[WARN]', 'yellow'), message)
-    elif type == "ERROR":
+    elif keyword == "ERROR":
         print(colored('[ERROR] ' + message, 'red'))
-    elif type == "INFO":
+    elif keyword == "INFO":
         print(colored('[INFO]', 'blue'), message)

--- a/Server/run.py
+++ b/Server/run.py
@@ -9,6 +9,6 @@ app = create_app(Config, LocalDBConfig)
 if __name__ == '__main__':
     if 'SECRET_KEY' not in os.environ:
         log(message='SECRET KEY is not set in the environment variable.',
-            type='WARN')
+            keyword='WARN')
 
     app.run(**app.config['RUN_SETTING'])


### PR DESCRIPTION
change arg 'type' to 'keyword' to not hide built-in name 'type'
also, add else case for additional keyword use case